### PR TITLE
Add test for deeply nested higher order expectations

### DIFF
--- a/src/main/kotlin/com/pestphp/pest/types/HigherOrderExtendTypeProvider.kt
+++ b/src/main/kotlin/com/pestphp/pest/types/HigherOrderExtendTypeProvider.kt
@@ -31,7 +31,7 @@ class HigherOrderExtendTypeProvider : PhpTypeProvider4 {
         return PhpType().add(firstParameterType).add(expectationType)
     }
 
-    private fun getExpectCall(reference: MemberReference, depth: Int = 50): FunctionReferenceImpl? {
+    private fun getExpectCall(reference: MemberReference, depth: Int = 100): FunctionReferenceImpl? {
         if (depth <= 0) return null
 
         return when (val classReference = reference.classReference) {

--- a/src/test/kotlin/com/pestphp/pest/higherOrderExpectations/HigherOrderExpectationCompletionTest.kt
+++ b/src/test/kotlin/com/pestphp/pest/higherOrderExpectations/HigherOrderExpectationCompletionTest.kt
@@ -1,7 +1,9 @@
 package com.pestphp.pest.higherOrderExpectations
 
+import com.intellij.testFramework.TestDataPath
 import com.pestphp.pest.PestLightCodeFixture
 
+@TestDataPath("\$CONTENT_ROOT/resources/com/pestphp/pest/higherOrderExpectations")
 class HigherOrderExpectationCompletionTest: PestLightCodeFixture() {
     override fun getTestDataPath(): String {
         return "src/test/resources/com/pestphp/pest/higherOrderExpectations"
@@ -53,5 +55,13 @@ class HigherOrderExpectationCompletionTest: PestLightCodeFixture() {
         )
 
         assertCompletion("getOtherExample", "getTest")
+    }
+
+    fun testMethodCompletionDeeplyChained() {
+        myFixture.configureByFile(
+            "ExpectMethodCompletionDeeplyChained.php"
+        )
+
+        assertCompletion("getTimestamp");
     }
 }

--- a/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectMethodCompletionDeeplyChained.php
+++ b/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectMethodCompletionDeeplyChained.php
@@ -1,0 +1,28 @@
+<?php
+
+class Chained
+{
+    public function getTimestamp()
+    {
+    }
+}
+
+class Example
+{
+    public function getDate(): Chained
+    {
+        return new Chained();
+    }
+}
+
+$example = new Example();
+
+expect($example)
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()->not->toBeNull()
+    ->getDate()-><caret>


### PR DESCRIPTION
This PR adds a tests showing an issue with higher order expectations not working when too many levels of nested calls.

- [x] Added or updated tests
- [ ] Updated `CHANGELOG.md`

issues: #...
