### PR TITLE
feat: Add `arch` test function

### DIFF
--- a/src/main/kotlin/com/pestphp/pest/PestFunctionsUtil.kt
+++ b/src/main/kotlin/com/pestphp/pest/PestFunctionsUtil.kt
@@ -19,7 +19,7 @@ fun PsiElement?.isPestTestReference(): Boolean {
     }
 }
 
-private val testNames = setOf("it", "test", "todo", "describe")
+private val testNames = setOf("it", "test", "todo", "describe", "arch")
 fun FunctionReferenceImpl.isPestTestFunction(): Boolean {
     return this.canonicalText in testNames
 }
@@ -32,7 +32,7 @@ fun FunctionReferenceImpl.isPestAfterFunction(): Boolean {
     return this.canonicalText == "afterEach"
 }
 
-private val allPestNames = setOf("it", "test", "todo", "beforeEach", "afterEach", "dataset", "describe")
+private val allPestNames = setOf("it", "test", "todo", "beforeEach", "afterEach", "dataset", "describe", "arch")
 fun FunctionReferenceImpl.isAnyPestFunction(): Boolean {
     return this.canonicalText in allPestNames
 }


### PR DESCRIPTION
Add support for an upcoming feature which allows you to write `arch` tests with `arch` function instead of `test` function. 

`arch` function is just a wrapper for `test` where it adds the group `arch` to it also. 

This is the PR adding the new function. It will be merged in very soon.
https://github.com/pestphp/pest-plugin-arch/pull/9
