### PR TITLE
WI-84920: Detect describe return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed infinite "Closing project..." dialog issue on project close
+- Fixed Pest files not being detected when `describe` is the only top-level call
 
 ### Changed
 

--- a/src/main/kotlin/com/pestphp/pest/PestFunctionsUtil.kt
+++ b/src/main/kotlin/com/pestphp/pest/PestFunctionsUtil.kt
@@ -20,6 +20,10 @@ val PEST_TEST_CALL_TYPE = PhpType.from(
     "\\Pest\\PendingObjects\\TestCall" // for Pest versions 1.x
 )
 
+val PEST_DESCRIBE_CALL_TYPE = PhpType.from(
+    "\\Pest\\PendingCalls\\DescribeCall" // for Pest versions >= 2.x
+)
+
 fun PsiElement?.isPestTestReference(isSmart: Boolean = false): Boolean {
     return when (this) {
         null -> false
@@ -32,9 +36,12 @@ fun PsiElement?.isPestTestReference(isSmart: Boolean = false): Boolean {
 private val testNames = setOf("it", "test", "todo", "describe", "arch")
 fun FunctionReferenceImpl.isPestTestFunction(isSmart: Boolean = false): Boolean {
     if (this.canonicalText !in testNames) return false
-    return !isSmart || (this.resolveLocal().isEmpty() && PhpIndex.getInstance(project).getFunctionsByName(this.canonicalText).any { function ->
-        PEST_TEST_CALL_TYPE.isConvertibleFromGlobal(project, function.type)
-    })
+    if (!isSmart) return true
+    if (this.resolveLocal().isNotEmpty()) return false
+    val expectedType = if (this.isDescribeFunction()) PEST_DESCRIBE_CALL_TYPE else PEST_TEST_CALL_TYPE
+    return PhpIndex.getInstance(project).getFunctionsByName(this.canonicalText).any { function ->
+        expectedType.isConvertibleFromGlobal(project, function.type)
+    }
 }
 
 fun FunctionReferenceImpl.isPestBeforeFunction(): Boolean {

--- a/src/test/kotlin/com/pestphp/pest/utilTests/IsPestTestFileTest.kt
+++ b/src/test/kotlin/com/pestphp/pest/utilTests/IsPestTestFileTest.kt
@@ -49,4 +49,16 @@ class IsPestTestFileTest : PestLightCodeFixture() {
 
         assertTrue(file.isPestTestFile())
     }
+
+    fun testDescribeOnlyFileIsPestTest() {
+        val file = myFixture.configureByFile("PestDescribeBlock.php")
+
+        assertTrue(file.isPestTestFile())
+    }
+
+    fun testDescribeOnlyFileIsPestTestSmart() {
+        val file = myFixture.configureByFile("PestDescribeBlock.php")
+
+        assertTrue(file.isPestTestFile(isSmart = true))
+    }
 }


### PR DESCRIPTION
When `describe` was used at the top level of the test file, its return type was not getting detected.

- [x] Added or updated tests
- [x] Updated `CHANGELOG.md`

issues: #WI-84920

https://youtrack.jetbrains.com/issue/WI-84920/Pest-Files-with-describe-blocks-are-not-recognized-as-tests
